### PR TITLE
chore: .cursor設定を移植・適合しGit管理対象外に設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Cursor AI configuration (development-specific)
+.cursor/


### PR DESCRIPTION
## 概要
.cursorディレクトリをGit管理対象外に設定

## 変更内容
- `.gitignore`に`.cursor/`を追加

## 理由
- `.cursor/`ディレクトリはCursor AI向けの開発環境設定ファイル群
- 個人の開発環境に依存する設定のため、リポジトリ管理対象外が適切
- プロジェクト固有ではなく、開発者個人の設定として扱う